### PR TITLE
Fixed cache issue in $imagekeys

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6953,7 +6953,7 @@ class TCPDF {
 			// create temp alpha file
 			$tempfile_alpha = K_PATH_CACHE.'__tcpdf_imgmask_alpha_'.$filehash;
 			// check for cached images
-			if (in_array($tempfile_plain, $this->imagekeys)) {
+			if (in_array($tempfile_plain, $this->imagekeys) && file_exists($tempfile_plain)) {
 				// get existing image data
 				$info = $this->getImageBuffer($tempfile_plain);
 				// check if the newer image is larger


### PR DESCRIPTION
Sometimes the disk cache for images is deleted but the image is still present in $imagekeys, thus TCPDF looks all over the web for an inexisting image

Bug found in PrestaShop 1.6 when generating multiple invoices in a single PDF.
