### PR TITLE
Fix SVG 'use' with clipPaths.

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -24147,7 +24147,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 							$attribs['style'] = str_replace(';;',';',';'.$use['attribs']['style'].$attribs['style']);
 						}
 						$attribs = array_merge($use['attribs'], $attribs);
-						$this->startSVGElementHandler('use-tag', $use['name'], $attribs);
+						$this->startSVGElementHandler($parser, $use['name'], $attribs);
 						return;
 					}
 				}


### PR DESCRIPTION
Reverts a change introduced in version 6.0.047. Use the variable again as it may include other values besides 'use-tag' (e.g. 'clip-path').
