### PR TITLE
Variable 'tcpdf_images_path' might have not been defined

### DIFF
--- a/tcpdf_autoconfig.php
+++ b/tcpdf_autoconfig.php
@@ -94,10 +94,10 @@ if (!defined('K_PATH_IMAGES')) {
 	$tcpdf_images_dirs = array(K_PATH_MAIN.'examples/images/', K_PATH_MAIN.'images/', '/usr/share/doc/php-tcpdf/examples/images/', '/usr/share/doc/tcpdf/examples/images/', '/usr/share/doc/php/tcpdf/examples/images/', '/var/www/tcpdf/images/', '/var/www/html/tcpdf/images/', '/usr/local/apache2/htdocs/tcpdf/images/', K_PATH_MAIN);
 	foreach ($tcpdf_images_dirs as $tcpdf_images_path) {
 		if (@file_exists($tcpdf_images_path)) {
+			define ('K_PATH_IMAGES', $tcpdf_images_path);
 			break;
 		}
 	}
-	define ('K_PATH_IMAGES', $tcpdf_images_path);
 }
 
 if (!defined('PDF_HEADER_LOGO')) {


### PR DESCRIPTION
L'istruzione
define ('K_PATH_IMAGES', $tcpdf_images_path);
utilizza la variabile $tcpdf_images_path, ma esistono uno o più percorsi logici possibili in cui l'istruzione potrebbe fare riferimento ad una variabile non definita.
Esempio: se l'array $tcpdf_images_dirs è vuoto, o più probabilmente se sul filesystem non esiste nemmeno uno dei percorsi menzionati nell'array.

Portando l'istruzione
define ('K_PATH_IMAGES', $tcpdf_images_path);
dentro al blocco condizionale, ci si assicura che la variabile $tcpdf_images_path venga utilizzata solo se è stata definita.
